### PR TITLE
Update README.yaml with Github Module Reference

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -70,7 +70,7 @@ usage: |-
 
   ```hcl
   module "cloudwatch_event" {
-    source = "https://github.com/cloudposse/terraform-aws-cloudwatch-events.git?ref=master"
+    source = "github.com/cloudposse/terraform-aws-cloudwatch-events?ref=x.x.x"
 
     name          = var.name
     namespace     = var.namespace


### PR DESCRIPTION
## what
* Update Readme file with new recommended way to reference a Terraform Module on a Github Repo

## why

* Terraform now recommends using the short URL for detecting Github Repos. Check references section.
* The `init` command was failing with Terraform `1.2.9` when using the original value from the Readme file:

```bash
$ terraform init
Initializing modules...
Downloading https://github.com/cloudposse/terraform-aws-cloudwatch-events.git?ref=master for event_bridege_notify_sre_rules...
╷
│ Error: Failed to download module
│ 
│ Could not download module "event_bridege_notify_sre_rules" (event_bridge.tf:1) source code from "https://github.com/cloudposse/terraform-aws-cloudwatch-events.git?ref=master": error downloading
│ 'https://github.com/cloudposse/terraform-aws-cloudwatch-events.git?ref=master': no source URL was returned
╵

╷
│ Error: Failed to download module
│ 
│ Could not download module "event_bridege_notify_sre_rules" (event_bridge.tf:1) source code from "https://github.com/cloudposse/terraform-aws-cloudwatch-events.git?ref=master": error downloading
│ 'https://github.com/cloudposse/terraform-aws-cloudwatch-events.git?ref=master': no source URL was returned
╵

$ terraform version
Terraform v1.2.9
on darwin_arm64
+ provider registry.terraform.io/hashicorp/aws v5.2.0

Your version of Terraform is out of date! The latest version
is 1.5.1. You can update by downloading from https://www.terraform.io/downloads.html
```

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->



## references

https://developer.hashicorp.com/terraform/language/modules/sources#github

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
