### PR TITLE
feat: Add optional Dead Letter Queue support for EventBridge targets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@ locals {
     ? var.cloudwatch_event_rule_state
     : (var.cloudwatch_event_rule_is_enabled ? "ENABLED" : "DISABLED")
   )
+  dlq_enabled = module.this.enabled && var.dead_letter_queue_enabled
 }
 
 
@@ -31,5 +32,62 @@ resource "aws_cloudwatch_event_target" "this" {
   target_id = var.cloudwatch_event_target_id
   arn       = var.cloudwatch_event_target_arn
   role_arn  = var.cloudwatch_event_target_role_arn
+
+  dynamic "dead_letter_config" {
+    for_each = local.dlq_enabled ? [1] : []
+    content {
+      arn = aws_sqs_queue.dlq[0].arn
+    }
+  }
+}
+
+# Dead Letter Queue for failed event deliveries
+# When EventBridge fails to deliver an event to a target, the event is normally dropped.
+# Enabling a DLQ captures failed events for troubleshooting delivery issues (e.g., permission errors).
+module "dlq_label" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  enabled    = local.dlq_enabled
+  attributes = ["dlq"]
+  context    = module.this.context
+}
+
+resource "aws_sqs_queue" "dlq" {
+  count = local.dlq_enabled ? 1 : 0
+
+  name                      = module.dlq_label.id
+  message_retention_seconds = var.dead_letter_queue_message_retention_seconds
+  tags                      = module.dlq_label.tags
+}
+
+data "aws_iam_policy_document" "dlq_policy" {
+  count = local.dlq_enabled ? 1 : 0
+
+  statement {
+    sid    = "AllowEventBridgeToSendMessages"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    actions   = ["sqs:SendMessage"]
+    resources = [aws_sqs_queue.dlq[0].arn]
+
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [aws_cloudwatch_event_rule.this.arn]
+    }
+  }
+}
+
+resource "aws_sqs_queue_policy" "dlq" {
+  count = local.dlq_enabled ? 1 : 0
+
+  queue_url = aws_sqs_queue.dlq[0].id
+  policy    = data.aws_iam_policy_document.dlq_policy[0].json
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,10 +10,10 @@ output "aws_cloudwatch_event_rule_arn" {
 
 output "dead_letter_queue_arn" {
   description = "The ARN of the Dead Letter Queue."
-  value       = one(aws_sqs_queue.dlq[*].arn)
+  value       = try(aws_sqs_queue.dlq[0].arn, null)
 }
 
 output "dead_letter_queue_url" {
   description = "The URL of the Dead Letter Queue."
-  value       = one(aws_sqs_queue.dlq[*].url)
+  value       = try(aws_sqs_queue.dlq[0].url, null)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,13 @@ output "aws_cloudwatch_event_rule_arn" {
   description = "The Amazon Resource Name (ARN) of the rule."
   value       = aws_cloudwatch_event_rule.this.arn
 }
+
+output "dead_letter_queue_arn" {
+  description = "The ARN of the Dead Letter Queue."
+  value       = one(aws_sqs_queue.dlq[*].arn)
+}
+
+output "dead_letter_queue_url" {
+  description = "The URL of the Dead Letter Queue."
+  value       = one(aws_sqs_queue.dlq[*].url)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -34,3 +34,15 @@ variable "cloudwatch_event_target_role_arn" {
   description = "IAM role to be used for this target when the rule is triggered."
   default     = null
 }
+
+variable "dead_letter_queue_enabled" {
+  type        = bool
+  description = "Enable a Dead Letter Queue (SQS) for failed event deliveries. Useful for troubleshooting delivery issues."
+  default     = false
+}
+
+variable "dead_letter_queue_message_retention_seconds" {
+  type        = number
+  description = "Number of seconds to retain messages in the Dead Letter Queue."
+  default     = 1209600 # 14 days (AWS default for DLQs)
+}

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.29"
     }
   }
 }


### PR DESCRIPTION
## What

Adds optional SQS Dead Letter Queue (DLQ) support for EventBridge targets.

## Why

When EventBridge fails to deliver an event to a target (e.g., SNS topic, Lambda function), the event is silently dropped by default. This makes troubleshooting delivery issues difficult since there's no visibility into failed events.

By enabling a DLQ, failed events are captured in an SQS queue where they can be:
- Inspected to understand why delivery failed
- Used to diagnose permission issues (e.g., missing SNS topic policy for EventBridge)
- Reprocessed after fixing the underlying issue

## Changes

- Added `dead_letter_queue_enabled` variable (default: `false`)
- Added `dead_letter_queue_message_retention_seconds` variable (default: 14 days)
- Added DLQ resources (SQS queue, IAM policy) when enabled
- Added `dead_letter_queue_arn` and `dead_letter_queue_url` outputs

## Breaking Changes

Bumps minimum AWS provider version from `>= 2.0` to `>= 3.29` (when `dead_letter_config` was added to `aws_cloudwatch_event_target`).

AWS provider 3.29 was released in February 2021.